### PR TITLE
Update kube api resources

### DIFF
--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -1,46 +1,77 @@
-{{ if .Values.api.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "brigade.fullname" . }}-api
+  creationTimestamp: null
   labels:
     app: {{ template "brigade.fullname" . }}-api
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
     role: api
+  name: {{ template "brigade.fullname" . }}-api
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: {{ template "brigade.fullname" . }}-api
+      role: api
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: {{ template "brigade.fullname" . }}-api
         role: api
     spec:
-      serviceAccountName: {{ template "brigade.api.fullname" . }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.api.registry }}/{{ .Values.api.name }}:{{ default .Chart.AppVersion .Values.api.tag }}"
-        imagePullPolicy: {{ default "IfNotPresent" .Values.api.pullPolicy }}
-        ports:
-        - containerPort: {{ .Values.api.service.internalPort }}
+      - env:
+        - name: BRIGADE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: BRIGADE_API_PORT
+          value: {{ .Values.api.service.internalPort | quote }}
+        image: '{{ .Values.api.registry }}/{{ .Values.api.name }}:{{ default .Chart.AppVersion
+          .Values.api.tag }}'
+        imagePullPolicy: {{ default "IfNotPresent" .Values.api.pullPolicy
+          }}
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
-            port: {{ .Values.api.service.internalPort }}
-{{ if .Values.api.livenessProbe }}{{ toYaml .Values.api.livenessProbe | indent 10 }}{{ end }}
+            port: 92427454
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: {{ .Chart.Name }}
+        ports:
+        - containerPort: 92427454
+          protocol: TCP
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
-            port: {{ .Values.api.service.internalPort }}
-{{ if .Values.api.readinessProbe }}{{ toYaml .Values.api.readinessProbe | indent 10 }}{{ end }}
-        env:
-          - name: BRIGADE_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: BRIGADE_API_PORT
-            value: {{ .Values.api.service.internalPort | quote }}
-      {{ if .Values.privateRegistry }}imagePullSecrets:
-        - name: {{.Values.privateRegistry}}{{ end }}
-{{ end }}
+            port: 92427454
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: {{ template "brigade.api.fullname" . }}
+      serviceAccountName: {{ template "brigade.api.fullname" . }}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -1,39 +1,66 @@
-{{ $fullname := include "brigade.ctrl.fullname" . }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $fullname }}
+  creationTimestamp: null
   labels:
     app: {{ $fullname }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
     role: controller
+  name: {{ $fullname }}
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: {{ $fullname }}
+      role: controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: {{ $fullname }}
         role: controller
     spec:
-      serviceAccountName: {{ $fullname }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.controller.registry }}/{{ .Values.controller.name }}:{{ default .Chart.AppVersion .Values.controller.tag }}"
-        imagePullPolicy: {{ default "IfNotPresent" .Values.controller.pullPolicy }}
+      - env:
+        - name: BRIGADE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: BRIGADE_WORKER_IMAGE
+          value: '{{ .Values.worker.registry }}/{{ .Values.worker.name }}:{{ default
+            .Chart.AppVersion .Values.worker.tag }}'
+        - name: BRIGADE_WORKER_PULL_POLICY
+          value: {{ default "IfNotPresent" .Values.worker.pullPolicy
+            }}
+        - name: BRIGADE_WORKER_SERVICE_ACCOUNT
+          value: {{ default "brigade-worker" .Values.worker.serviceAccount
+            }}
+        image: '{{ .Values.controller.registry }}/{{ .Values.controller.name }}:{{
+          default .Chart.AppVersion .Values.controller.tag }}'
+        imagePullPolicy: {{ default "IfNotPresent" .Values.controller.pullPolicy
+          }}
+        name: {{ .Chart.Name }}
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
-        env:
-          - name: BRIGADE_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: BRIGADE_WORKER_IMAGE
-            value: "{{ .Values.worker.registry }}/{{ .Values.worker.name }}:{{ default .Chart.AppVersion .Values.worker.tag }}"
-          - name: BRIGADE_WORKER_PULL_POLICY
-            value: {{ default "IfNotPresent" .Values.worker.pullPolicy }}
-          - name: BRIGADE_WORKER_SERVICE_ACCOUNT
-            value: {{ default "brigade-worker" .Values.worker.serviceAccount }}
-      {{ if .Values.privateRegistry }}imagePullSecrets:
-        - name: {{.Values.privateRegistry}}{{ end }}
+        - containerPort: 92427454
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: {{ $fullname }}
+      serviceAccountName: {{ $fullname }}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/charts/brigade/templates/gateway-cr-deployment.yaml
+++ b/charts/brigade/templates/gateway-cr-deployment.yaml
@@ -1,45 +1,78 @@
-{{ if .Values.cr.enabled }}
-{{ $fullname := include "brigade.cr.fullname" . }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $fullname }}
+  creationTimestamp: null
   labels:
     app: {{ template "brigade.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
     role: gateway
     type: dockerhub
+  name: {{ $fullname }}
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: {{ template "brigade.fullname" . }}
+      role: gateway
+      type: dockerhub
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: {{ template "brigade.fullname" . }}
         role: gateway
         type: dockerhub
     spec:
-      serviceAccountName: {{ $fullname }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.cr.registry }}/{{ .Values.cr.name }}:{{ default .Chart.AppVersion .Values.cr.tag }}"
-        imagePullPolicy: {{ default "IfNotPresent" .Values.cr.pullPolicy }}
-        ports:
-        - containerPort: {{ .Values.cr.service.internalPort }}
+      - env:
+        - name: BRIGADE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: '{{ .Values.cr.registry }}/{{ .Values.cr.name }}:{{ default .Chart.AppVersion
+          .Values.cr.tag }}'
+        imagePullPolicy: {{ default "IfNotPresent" .Values.cr.pullPolicy
+          }}
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
-            port: {{ .Values.cr.service.internalPort }}
+            port: 92427454
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: {{ .Chart.Name }}
+        ports:
+        - containerPort: 92427454
+          protocol: TCP
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
-            port: {{ .Values.cr.service.internalPort }}
-        env:
-          - name: BRIGADE_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-      {{ if .Values.privateRegistry }}imagePullSecrets:
-        - name: {{.Values.privateRegistry}}{{ end }}
-{{ end }}
+            port: 92427454
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: {{ $fullname }}
+      serviceAccountName: {{ $fullname }}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/charts/brigade/templates/gateway-github-deployment.yaml
+++ b/charts/brigade/templates/gateway-github-deployment.yaml
@@ -1,49 +1,81 @@
-{{ if .Values.gw.enabled }}
-{{ $fullname := include "brigade.gw.fullname" . }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $fullname }}
+  creationTimestamp: null
   labels:
     app: {{ template "brigade.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
     role: gateway
     type: github
+  name: {{ $fullname }}
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: {{ template "brigade.fullname" . }}
+      role: gateway
+      type: github
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: {{ template "brigade.fullname" . }}
         role: gateway
         type: github
     spec:
-      serviceAccountName: {{ $fullname }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.gw.registry }}/{{ .Values.gw.name }}:{{ default .Chart.AppVersion .Values.gw.tag }}"
-        imagePullPolicy: {{ default "IfNotPresent" .Values.gw.pullPolicy }}
-        ports:
-        - containerPort: {{ .Values.service.internalPort }}
+      - env:
+        - name: BRIGADE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: BRIGADE_GATEWAY_PORT
+          value: {{ .Values.service.internalPort | quote }}
+        - name: BRIGADE_AUTHORS
+        image: '{{ .Values.gw.registry }}/{{ .Values.gw.name }}:{{ default .Chart.AppVersion
+          .Values.gw.tag }}'
+        imagePullPolicy: {{ default "IfNotPresent" .Values.gw.pullPolicy
+          }}
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
-            port: {{ .Values.service.internalPort }}
+            port: 92427454
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: {{ .Chart.Name }}
+        ports:
+        - containerPort: 92427454
+          protocol: TCP
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
-            port: {{ .Values.service.internalPort }}
-        env:
-          - name: BRIGADE_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: BRIGADE_GATEWAY_PORT
-            value: {{ .Values.service.internalPort | quote }}
-          - name: BRIGADE_AUTHORS
-            value: {{ if .Values.gw.allowedAuthorRoles }}{{ join "," .Values.gw.allowedAuthorRoles | quote }}{{ end }}
-      {{ if .Values.privateRegistry }}imagePullSecrets:
-        - name: {{.Values.privateRegistry}}{{ end }}
-{{ end }}
+            port: 92427454
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: {{ $fullname }}
+      serviceAccountName: {{ $fullname }}
+      terminationGracePeriodSeconds: 30
+status: {}


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team